### PR TITLE
fix(prefs): readability improvements for sidebar menus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,24 +40,27 @@ document.addEventListener("DOMContentLoaded", function() {
       --background-elevated: #222;
       --border-bright: #89b9c4;
       --text-special: #89b9c4;
-   }
-   .bot_message .message_sender a, .c-member__name span, #details_tab div, .current_status_placeholder, 
-   #details_tab span, #fs_modal #fs_modal_sidebar a, #im_browser span, #member_preview_scroller div, 
-   #member_preview_scroller span, .p-apps_browser__app_name strong, span.c-message__body, a.c-message__sender_link, span.c-message_attachment__text, 
-   span.c-message_attachment__media_trigger.c-message_attachment__media_trigger--caption, div.p-message_pane__foreword__description span {
+    }
+    .bot_message .message_sender a, .c-member__name span, #details_tab div, .current_status_placeholder, 
+    #details_tab span, #fs_modal #fs_modal_sidebar a, #im_browser span, #member_preview_scroller div, .c-message_attachment, 
+    #member_preview_scroller span, .p-apps_browser__app_name strong, span.c-message__body, 
+    a.c-message__sender_link, div.p-message_pane__foreword__description span {
       color: var(--text) !important;
-   }
-   #details_tab a, #member_preview_scroller a {
+    }
+    #details_tab a, #member_preview_scroller a {
       color: var(--primary) !important;
-   }
-  .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
-  .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
-  .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) {
-      background-color: var(--background-hover) !important;
-  }
-  .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
-    height: 5px; 
-  }  
+    }
+    .c-mrkdwn__broadcast, .c-mrkdwn__broadcast--linkm, .c-mrkdwn__broadcast--mention {
+      color: var(--text-special) !important;
+    }
+    .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
+    .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
+    .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) {
+        background-color: var(--background-hover) !important;
+    }
+    .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
+      height: 5px; 
+    }  
    `
 
    // Insert a style tag into the wrapper view

--- a/readme.md
+++ b/readme.md
@@ -43,12 +43,21 @@ document.addEventListener("DOMContentLoaded", function() {
    }
    .bot_message .message_sender a, .c-member__name span, #details_tab div, .current_status_placeholder, 
    #details_tab span, #fs_modal #fs_modal_sidebar a, #im_browser span, #member_preview_scroller div, 
-   #member_preview_scroller span, .p-apps_browser__app_name strong {
+   #member_preview_scroller span, .p-apps_browser__app_name strong, span.c-message__body, a.c-message__sender_link, span.c-message_attachment__text, 
+   span.c-message_attachment__media_trigger.c-message_attachment__media_trigger--caption, div.p-message_pane__foreword__description span {
       color: var(--text) !important;
    }
    #details_tab a, #member_preview_scroller a {
       color: var(--primary) !important;
    }
+  .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
+  .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), 
+  .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) {
+      background-color: var(--background-hover) !important;
+  }
+  .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
+    height: 5px; 
+  }  
    `
 
    // Insert a style tag into the wrapper view

--- a/readme.md
+++ b/readme.md
@@ -38,10 +38,16 @@ document.addEventListener("DOMContentLoaded", function() {
       --text: #CCC;
       --background: #080808;
       --background-elevated: #222;
+      --border-bright: #89b9c4;
+      --text-special: #89b9c4;
    }
-   #fs_modal #fs_modal_sidebar a {
-       color: var(--text) !important;
-   }   
+   #details_tab div, #details_tab span, #fs_modal #fs_modal_sidebar a, #member_preview_scroller div, 
+   .current_status_placeholder, #member_preview_scroller span {
+      color: var(--text) !important;
+   }
+    #details_tab a, #member_preview_scroller a {
+      color: var(--primary) !important;
+    }
    `
 
    // Insert a style tag into the wrapper view

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ document.addEventListener("DOMContentLoaded", function() {
       --background: #080808;
       --background-elevated: #222;
    }
+   #fs_modal #fs_modal_sidebar a {
+       color: var(--text) !important;
+   }   
    `
 
    // Insert a style tag into the wrapper view

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,9 @@ document.addEventListener("DOMContentLoaded", function() {
       --border-bright: #89b9c4;
       --text-special: #89b9c4;
    }
-   #details_tab div, #details_tab span, #fs_modal #fs_modal_sidebar a, #member_preview_scroller div, 
-   .current_status_placeholder, #member_preview_scroller span {
+   .bot_message .message_sender a, .c-member__name span, #details_tab div, .current_status_placeholder, 
+   #details_tab span, #fs_modal #fs_modal_sidebar a, #im_browser span, #member_preview_scroller div, 
+   #member_preview_scroller span, .p-apps_browser__app_name strong {
       color: var(--text) !important;
    }
     #details_tab a, #member_preview_scroller a {


### PR DESCRIPTION
EDIT: this fix now includes a bunch of readability improvements for the latest version of slack which broke some of the dark theme text colors.

This will apply the theme text color you chose to preferences menu, channel details sidebar, and profile sidebar, which are otherwise difficult to read. They'll look something like this now: 

![screen shot 2017-12-21 at 11 24 46 am](https://user-images.githubusercontent.com/3981723/34264651-90fde188-e641-11e7-8c00-bea90adc1435.png)

