### PR TITLE
Update for windows 10 users as of 3.2.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,23 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 ```
 
+For Windows 10 users as of 3.2.0, do the following additional steps to the above:
+
+In `resources\app.asar.unpacked\src\static\ssb-interop.js` add the following at the end of the above code (tested for Windows 10 users):
+
+```
+document.addEventListener('DOMContentLoaded', function() {
+  $.ajax({
+   url: 'https://cdn.rawgit.com/laCour/slack-night-mode/master/css/raw/black.css',
+   success: function(css) {
+     $("<style></style>").appendTo('head').html(css);
+   }
+ });
+});
+```
+
+Additionally, make a `custom.css` file in the path `resources\app.asar.unpacked\src\static` and add the raw code found in the `custom.css` file of this repo (tested for Windows 10 users).
+
 Notice that you can edit any of the theme colors using the custom CSS (for
 the already-custom theme.) Also, you can put any CSS URL you want here,
 so you don't necessarily need to create an entire fork to change some small styles.


### PR DESCRIPTION
Windows 10 seems to not apply black unless the proposed additions are made. 