### PR TITLE
fix threads reply button and channel title gap

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -213,8 +213,8 @@ li.active[class] span,
 
 #client_body::before, #client_body:not(.onboarding):before {
   border-bottom: 1px solid var(--border-dim) !important;
-  background: var(--background);
-  box-shadow: none;
+  background: var(--background) !important;
+  box-shadow: none !important;
 }
 
 #client_body, #messages_container.has_top_messages_banner:before {
@@ -232,6 +232,12 @@ ts-jumper input[type="text"]::-webkit-input-placeholder {
 }
 
 #msg_input, #primary_file_button {
+  background: transparent !important;
+  color: var(--text) !important;
+  border-color: var(--border-dim) !important;
+}
+
+.inline_message_input_container, .inline_file_upload {
   background: transparent !important;
   color: var(--text) !important;
   border-color: var(--border-dim) !important;


### PR DESCRIPTION
Fixes two blank space CSS issues.

in "All Threads" view:
![screenshot_2018-09-07_22-40-35](https://user-images.githubusercontent.com/505621/45249494-4509d400-b2ef-11e8-9837-f59b28e64edf.png)

in any channel:
![screenshot_2018-09-07_22-40-14](https://user-images.githubusercontent.com/505621/45249495-4509d400-b2ef-11e8-9490-e8e30f89b101.png)
