### PR TITLE
Fixed indentation and quotes in sample code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,48 +27,47 @@ At the very bottom, add
 // First make sure the wrapper app is loaded
 document.addEventListener("DOMContentLoaded", function() {
 
-   // Then get its webviews
-   let webviews = document.querySelectorAll(".TeamView webview");
+  // Then get its webviews
+  let webviews = document.querySelectorAll(".TeamView webview");
 
-   // Fetch our CSS in parallel ahead of time
-   const cssPath = 'https://cdn.rawgit.com/widget-/slack-black-theme/master/custom.css';
-   let cssPromise = fetch(cssPath).then(response => response.text());
+  // Fetch our CSS in parallel ahead of time
+  const cssPath = "https://cdn.rawgit.com/widget-/slack-black-theme/master/custom.css";
+  let cssPromise = fetch(cssPath).then(response => response.text());
 
-   let customCustomCSS = `
-   :root {
-      /* Modify these to change your theme colors: */
-      --primary: #09F;
-      --text: #CCC;
-      --background: #080808;
-      --background-elevated: #222;
-   }
-   `
+  let customCustomCSS = `
+  :root {
+    /* Modify these to change your theme colors: */
+    --primary: #09F;
+    --text: #CCC;
+    --background: #080808;
+    --background-elevated: #222;
+  }`
 
-   // Insert a style tag into the wrapper view
-   cssPromise.then(css => {
-      let s = document.createElement('style');
-      s.type = 'text/css';
-      s.innerHTML = css + customCustomCSS;
-      document.head.appendChild(s);
-   });
+  // Insert a style tag into the wrapper view
+  cssPromise.then(css => {
+    let s = document.createElement("style");
+    s.type = "text/css";
+    s.innerHTML = css + customCustomCSS;
+    document.head.appendChild(s);
+  });
 
-   // Wait for each webview to load
-   webviews.forEach(webview => {
-      webview.addEventListener('ipc-message', message => {
-         if (message.channel == 'didFinishLoading')
-            // Finally add the CSS into the webview
-            cssPromise.then(css => {
-               let script = `
-                     let s = document.createElement('style');
-                     s.type = 'text/css';
-                     s.id = 'slack-custom-css';
-                     s.innerHTML = \`${css + customCustomCSS}\`;
-                     document.head.appendChild(s);
-                     `
-               webview.executeJavaScript(script);
-            })
-      });
-   });
+  // Wait for each webview to load
+  webviews.forEach(webview => {
+    webview.addEventListener("ipc-message", message => {
+      if (message.channel == "didFinishLoading")
+        // Finally add the CSS into the webview
+        cssPromise.then(css => {
+          let script = `
+            let s = document.createElement("style");
+            s.type = "text/css";
+            s.id = "slack-custom-css";
+            s.innerHTML = \`${css + customCustomCSS}\`;
+            document.head.appendChild(s);`
+
+          webview.executeJavaScript(script);
+        })
+    });
+  });
 });
 ```
 


### PR DESCRIPTION
I replaced 3-space by 2-space indentation (which makes editing way easier for most people), and replaced single quotes by double quotes (some folks might want to wrap it all in single quotes depending on what they use to apply it to Slack) in the README sample code.