### PR TITLE
Add launch slack with dev mode for linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ Instead of launching Slack normally, you'll need to enable developer mode to be 
 
 * Mac: `export SLACK_DEVELOPER_MENU=true; open -a /Applications/Slack.app`
 
-* Linux: (todo)
+* Linux: `export SLACK_DEVELOPER_MENU=true; slack` (when installed via snap)
 
 * Windows: (todo)
 


### PR DESCRIPTION
This seems to work for me with slack desktop installed with snap (via command line).
Command line launcher could potentially also be installed when installing slack using other methods (I haven't tried this though). As such could advise to check with `which slack` ?